### PR TITLE
Updates pre-saved compounds' data

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,15 @@ Currently, **NistChemPy** enables the extraction of basic compound properties as
 Additional properties are available via URLs that link to their respective web pages, with potential support for direct extraction in future updates.
 
 
+## Extracted data
+
+Before using **NistChemPy**, please check [NistChemData](https://github.com/IvanChernyshov/NistChemData).
+
+This repository contains information that has already been extracted from the WebBook using **NistChemPy** functionality.
+
+By doing so, you can bypass the web-scraping stage and proceed directly to data manipulation.
+
+
 ## Installation
 
 Install NistChemPy using [pip](https://pypi.org/project/NistChemPy/):

--- a/README.md
+++ b/README.md
@@ -24,5 +24,5 @@ pip install nistchempy
 
 ## How To
 
-The primary features of NistChemPy, such as search capabilities and compound manipulations, are detailed in the [documentation](https://ivanchernyshov.github.io/NistChemPy/source/api.html).
+The primary features of NistChemPy, such as search capabilities and compound manipulations, are detailed in the [documentation](https://ivanchernyshov.github.io/NistChemPy/).
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -23,8 +23,16 @@ Welcome to the NistChemPy's documentation!
 
 **NistChemPy** is an unofficial API for the `NIST Chemistry WebBook`_.
 This package not only automates the search and data extraction processes but also bypasses the WebBook's limitation of 400 compounds per search.
-Currently, NistChemPy enables the extraction of basic compound properties as well as IR, THz, MS, and UV-Vis spectra.
+Currently, **NistChemPy** enables the extraction of basic compound properties as well as IR, THz, MS, and UV-Vis spectra.
 Additional properties are available via URLs that link to their respective web pages, with potential support for direct extraction in future updates.
+
+
+Extracted data
+==============
+
+Before using **NistChemPy**, please check `NistChemData`_.
+This repository contains information that has already been extracted from the WebBook using **NistChemPy** functionality.
+By doing so, you can bypass the web-scraping stage and proceed directly to data manipulation.
 
 
 Installation
@@ -56,8 +64,9 @@ Useful links
 
 1. `NIST Chemistry WebBook`_: webapp accessing the NIST Chemistry WebBook database.
 2. `GitHub`_: GitHub page of the package.
-3. `PyPI package`_: PyPI page of the package.
-4. `Update tools`_: script for semi-automatic update of structural information of new NIST Chemistry WebBook compounds.
+3. `NistChemData`_: Repository containing already extracted WebBook's data.
+4. `PyPI package`_: PyPI page of the package.
+5. `Update tools`_: script for semi-automatic update of structural information of new NIST Chemistry WebBook compounds.
 
 
 Indices and tables
@@ -68,6 +77,7 @@ Indices and tables
 
 
 
+.. _NistChemData: https://github.com/IvanChernyshov/NistChemData
 .. _NIST Chemistry WebBook: https://webbook.nist.gov/chemistry/
 .. _GitHub: https://github.com/IvanChernyshov/NistChemPy
 .. _PyPI package: https://pypi.org/project/nistchempy/

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -4,7 +4,11 @@ Changelog
 1.0.2
 -----
 
-* Fixes some missing data fields in pre-saved data on compounds (:py:func:`nistchempy.compound_list.get_all_data`).
+* Adds c.a. 10 000 of missing InChI strings to the pre-saved data on compounds (:py:func:`nistchempy.compound_list.get_all_data`).
+
+* Fixes bug in update resulted in c.a. 10 000 of missing InChI strings.
+
+* Fixes chemical formula parser.
 
 * Adds reference to repo containing data extracted from NIST Chemistry WebBook (`NistChemData <https://github.com/IvanChernyshov/NistChemData>`_).
 

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,6 +1,14 @@
 Changelog
 =========
 
+1.0.2
+-----
+
+* Fixes some missing data fields in pre-saved data on compounds (:py:func:`nistchempy.compound_list.get_all_data`).
+
+* Adds reference to repo containing data extracted from NIST Chemistry WebBook (`NistChemData <https://github.com/IvanChernyshov/NistChemData>`_).
+
+
 1.0.1
 -----
 

--- a/nistchempy/__init__.py
+++ b/nistchempy/__init__.py
@@ -4,8 +4,8 @@ automatic retrievement of the stored physico-chemical data
 
 '''
 
-__version__ = '1.0.1'
-__updated__ = 'September 25, 2024'
+__version__ = '1.0.2'
+__updated__ = 'September 29, 2024'
 __license__ = 'MIT'
 
 

--- a/nistchempy/parsing.py
+++ b/nistchempy/parsing.py
@@ -205,6 +205,8 @@ def get_compound_formula(soup: _bs4.BeautifulSoup) -> _tp.Optional[str]:
     hits = info.findChildren(string = _re.compile('Formula'))
     if hits:
         formula = hits[0].findParent('li').text.replace('Formula:', '').strip()
+        formula = _re.sub('Monomer', '', formula).strip()
+        formula = _re.sub(r'\s+', ' ', formula)
         #formula = _re.sub(r'(\d)([a-zA-Z])', r'\1 \2', formula)
         #formula = _re.sub(r'([a-zA-Z])([A-Z])', r'\1 \2', formula)
     

--- a/update/README.md
+++ b/update/README.md
@@ -31,4 +31,6 @@ Possible errors must be manually verified to fix bugs in NistChemPy code.
 
 6. [extract_info_from_htmls.py](extract_info_from_htmls.py): extracts info on compounds from prepared compound HTMLs and saves it as if final nist_data.csv final required for the package.
 
+7. [get_old_IDs.py](get_old_IDs.py): tries to download HTML-pages of compounds that are missing in current nist_data.csv file, but is available in old versions. If there are such entries, the previous script must be re-executed.
+
 

--- a/update/check_compound_initialization.py
+++ b/update/check_compound_initialization.py
@@ -55,7 +55,7 @@ def get_unreadable_compounds(dir_html: str) -> List[str]:
         idx = int(f.replace('.html', ''))
         path = os.path.join(dir_html, f)
         with open(path, 'r') as inpf:
-            text = inpf.read()
+            text = nist.requests.fix_html(inpf.read())
         soup = BeautifulSoup(text, 'html.parser')
         # check
         flag = check_soup(soup)

--- a/update/get_missing_stereoisomers.py
+++ b/update/get_missing_stereoisomers.py
@@ -66,7 +66,7 @@ def get_missing_stereoisomers(dir_html: str) -> List[str]:
         # get soup
         path = os.path.join(dir_html, f)
         with open(path, 'r') as inpf:
-            text = inpf.read()
+            text = nist.requests.fix_html(inpf.read())
         soup = BeautifulSoup(text, 'html.parser')
         # extract ID
         if nist.parsing.is_compound_page(soup):
@@ -193,7 +193,7 @@ def main() -> None:
     loaded = []
     for f in tqdm(os.listdir(dir_stereo)):
         with open(os.path.join(dir_stereo, f), 'r') as inpf:
-            text = inpf.read()
+            text = nist.requests.fix_html(inpf.read())
             soup = BeautifulSoup(text, 'html.parser')
         if nist.parsing.is_compound_page(soup):
             ID = f.replace('.html', '')

--- a/update/get_old_IDs.py
+++ b/update/get_old_IDs.py
@@ -1,0 +1,161 @@
+'''Tries to download HTMLs for compounds available in old dataset but missing
+in the current one'''
+
+#%% Imports
+
+import os, time
+import argparse
+
+import requests
+
+import pandas as pd
+
+from tqdm import tqdm
+
+import nistchempy as nist
+
+from typing import List
+
+
+#%% Functions
+
+def get_missing_entries(dir_data: str, path_old: str) -> List[str]:
+    '''Extracts entries missing from the old data
+    
+    Arguments:
+        dir_data (str): directory containing compound.csv file created by get_nist_compounds.py script
+        path_old (str): old nist_data.csv file
+    
+    Returns:
+        List[str]: list of compound IDs of missing compounds
+    
+    '''
+    # read data
+    path_new = os.path.join(dir_data, 'nist_data.csv')
+    new = pd.read_csv(path_new)
+    old = pd.read_csv(path_old)
+    
+    # get missing IDs
+    IDs = set(old['ID']).difference(set(new['ID']))
+    IDs = sorted(list(IDs))
+    
+    return IDs
+
+
+
+def download_missing_htmls(IDs: List[str], dir_out: str,
+                           crawl_delay: float = 5) -> None:
+    '''Downloads compound pages for stereoisomers
+    
+    Arguments:
+        IDs (List[str]): list of compound IDs of missing compounds
+        dir_out (str): directory to save HTML pages of compounds
+        crawl_delay (float): interval between HTTP requests, seconds
+    
+    '''
+    # download cycle
+    for ID in tqdm(IDs, total = len(IDs)):
+        time.sleep(crawl_delay)
+        path_html = os.path.join(dir_out, f'{ID}.html')
+        url = nist.requests.SEARCH_URL + f'?ID={ID}'
+        try:
+            #nr = nist.requests.make_nist_request(url)
+            nr = requests.get(url)
+            if nr.text and nr.text.strip():
+                with open(path_html, 'w') as outf:
+                    outf.write(nr.text)
+        except (KeyboardInterrupt, SystemError, SystemExit):
+            raise
+        except:
+            tqdm.write(f'Error with downloading Compound: {ID}')
+    
+    return
+
+
+
+
+#%% Main functions
+
+def get_arguments() -> argparse.Namespace:
+    '''CLI wrapper
+    
+    Returns:
+        argparse.Namespace: CLI arguments
+    
+    '''
+    parser = argparse.ArgumentParser(description = 'Downloads HTML-pages of NIST Chemistry WebBook compounds')
+    parser.add_argument('dir_data',
+                        help = 'directory containing compound.csv file created by get_nist_compounds.py script')
+    parser.add_argument('path_old',
+                        help = 'old nist_data.csv file')
+    parser.add_argument('--crawl-delay', type = float, default = 5,
+                        help = 'pause between HTTP requests, seconds')
+    args = parser.parse_args()
+    
+    return args
+
+
+def check_arguments(args: argparse.Namespace) -> None:
+    '''Tries to create dir_data if it does not exist and raizes error if dir_data is a file
+    
+    Arguments:
+        args (argparse.Namespace): input parameters
+    
+    '''
+    
+    # check root dir
+    if not os.path.exists(args.dir_data):
+        raise ValueError(f'Given dir_data argument does not exist: {args.dir_data}')
+    if not os.path.isdir(args.dir_data):
+        raise ValueError(f'Given dir_data argument is not a directory: {args.dir_data}')
+    
+    # check old compounds.csv
+    if not os.path.exists(args.path_old):
+        raise ValueError(f'Given path_old argument does not exist: {args.path_old}')
+    
+    # check new compounds.csv
+    path_new = os.path.join(args.dir_data, 'nist_data.csv')
+    if not os.path.exists(path_new):
+        raise ValueError('Given dir_data does not contain nist_data.csv file')
+    
+    # check old dir
+    dir_out = os.path.join(args.dir_data, 'htmls_old')
+    if not os.path.exists(dir_out):
+        os.mkdir(dir_out)
+    
+    # crawl delay
+    if args.crawl_delay < 0:
+        raise ValueError(f'--crawl-delay must be positive: {args.crawl_delay}')
+    
+    return
+
+
+def main() -> None:
+    '''Updates the list of NIST compounds via downloaded HTML pages'''
+    
+    # prepare arguments
+    args = get_arguments()
+    check_arguments(args)
+    
+    # load compounds
+    print('\nGetting missing IDs ...')
+    IDs = get_missing_entries(args.dir_data, args.path_old)
+    
+    # download stereoisomers
+    print('\nDownloading missing HTMLs ...')
+    dir_out = os.path.join(args.dir_data, 'htmls_old')
+    download_missing_htmls(IDs, dir_out, args.crawl_delay)
+    print()
+    
+    return
+
+
+
+#%% Main
+
+if __name__ == '__main__':
+    
+    main()
+
+
+


### PR DESCRIPTION
- Adds c.a. 10 000 of missing InChI strings to the pre-saved data on compounds.
- Fixes bug in update resulted in c.a. 10 000 of missing InChI strings.
- Fixes chemical formula parser.
- Adds reference to repo containing data extracted from NIST Chemistry WebBook.
